### PR TITLE
Update to Original openSSL

### DIFF
--- a/ssl/build.info
+++ b/ssl/build.info
@@ -22,7 +22,7 @@ SOURCE[../libssl]=\
 # in libssl as well.
 SHARED_SOURCE[../libssl]=\
         ../crypto/packet.c ../crypto/quic_vlint.c ../crypto/time.c \
-        ../crypto/hashtable/hashfunc.c ../crypto/siphash/siphash.c
+        ../crypto/hashtable/hashfunc.c
 
 IF[{- !$disabled{'deprecated-3.0'} -}]
   SOURCE[../libssl]=ssl_rsa_legacy.c
@@ -30,4 +30,9 @@ ENDIF
 
 IF[{- !$disabled{quic} -}]
   SOURCE[../libssl]=priority_queue.c
+  IF[{- $disabled{siphash} -}]
+    SOURCE[../libssl]=../crypto/siphash/siphash.c
+  ELSE
+    SHARED_SOURCE[../libssl]=../crypto/siphash/siphash.c
+  ENDIF
 ENDIF


### PR DESCRIPTION
SHARED_SOURCE doesn't pull in siphash if its disabled in the configuration leading to undefined symbols, which we need for quic.

If siphash is disabled in the build, then pull it in via a SOURCE addition, otherwise pull it in via SHARED_SOURCE

Reviewed-by: Tim Hudson <tjh@openssl.org>
Reviewed-by: Tomas Mraz <tomas@openssl.org>
(Merged from https://github.com/openssl/openssl/pull/26874)

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
